### PR TITLE
Add 'yes' flag to apt-get autoremove

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -62,4 +62,4 @@ rm -rf phantomjs*
 
 # Clean stuff up that's no longer needed
 apt-get remove build-essential && apt-get purge build-essential
-apt-get autoclean && apt-get autoremove && apt-get clean
+apt-get autoclean && apt-get autoremove -y && apt-get clean


### PR DESCRIPTION
Without the -y flag, if a program was to be removed the script would
fail as it will ask for input.
